### PR TITLE
Fix header guards and cleanup settings manager

### DIFF
--- a/main/core/network_manager.h
+++ b/main/core/network_manager.h
@@ -82,10 +82,3 @@ bool network_manager_load_wifi_credentials(char *ssid, size_t ssid_len,
 
 
 #endif /* CORE_NETWORK_MANAGER_H */
-
-
-#endif /* CORE_NETWORK_MANAGER_H */
-
-#endif /* CORE_NETWORK_MANAGER_H */
- main
- main

--- a/main/core/settings_manager.c
+++ b/main/core/settings_manager.c
@@ -133,11 +133,5 @@ bool settings_has_key(const char* key) {
     int32_t dummy;
     esp_err_t err = nvs_get_i32(settings_handle, key, &dummy);
     return err != ESP_ERR_NVS_NOT_FOUND;
-
-}
-
-
-}
-
 }
 

--- a/main/core/settings_manager.h
+++ b/main/core/settings_manager.h
@@ -49,7 +49,3 @@ static inline bool settings_has_display_type(void) {
 
 #endif /* SETTINGS_MANAGER_H */
 
-#endif /* SETTINGS_MANAGER_H */
-
-#endif /* SETTINGS_MANAGER_H */
-


### PR DESCRIPTION
## Summary
- remove duplicate header guards and stray text in `network_manager.h`
- clean up repeated `#endif` in `settings_manager.h`
- trim extraneous closing braces in `settings_manager.c`

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405c078c34832394469db714f270be