### PR TITLE
Fix duplicate header guards

### DIFF
--- a/main/core/network_manager.h
+++ b/main/core/network_manager.h
@@ -80,12 +80,4 @@ bool network_manager_load_wifi_credentials(char *ssid, size_t ssid_len,
                                            char *password, size_t pass_len,
                                            rc_wifi_mode_t *mode);
 
-
 #endif /* CORE_NETWORK_MANAGER_H */
-
-
-#endif /* CORE_NETWORK_MANAGER_H */
-
-#endif /* CORE_NETWORK_MANAGER_H */
- main
- main

--- a/main/core/settings_manager.h
+++ b/main/core/settings_manager.h
@@ -49,7 +49,3 @@ static inline bool settings_has_display_type(void) {
 
 #endif /* SETTINGS_MANAGER_H */
 
-#endif /* SETTINGS_MANAGER_H */
-
-#endif /* SETTINGS_MANAGER_H */
-


### PR DESCRIPTION
## Summary
- remove stray lines from `network_manager.h`
- clean up extra `#endif` lines in `settings_manager.h`

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405c07721083239c44ec42fd35f226